### PR TITLE
Past launches with order, launch_year and reused filters

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,7 +16,7 @@ export class MyApp {
   @ViewChild(Nav) nav: Nav;
   rootPage: any = HomePage;
 
-  pages: Array<{title: string, component: any}>;
+  pages: Array<{title: string, component: any, icon: any}>;
 
   constructor(platform: Platform, statusBar: StatusBar, splashScreen: SplashScreen) {
     platform.ready().then(() => {
@@ -27,11 +27,11 @@ export class MyApp {
     });
 
     this.pages = [
-      { title: 'Home', component: HomePage },
-      { title: 'About', component: AboutPage },
-      { title: 'Rockets', component: RocketsPage },
-      { title: 'Capsule', component: CapsulesPage },
-      { title: 'Launches', component: LaunchesPage }
+      { title: 'Home', component: HomePage, icon: 'home' },
+      { title: 'About', component: AboutPage, icon: 'information-circle' },
+      { title: 'Rockets', component: RocketsPage, icon: 'jet' },
+      { title: 'Capsule', component: CapsulesPage, icon: 'moon' },
+      { title: 'Missions', component: LaunchesPage, icon: 'planet' }
     ];
   }
 

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -8,7 +8,7 @@
   <ion-content>
     <ion-list>
       <button menuClose ion-item *ngFor="let p of pages" (click)="openPage(p)">
-        {{p.title}}
+        <ion-icon name="{{p.icon}}"></ion-icon> {{p.title}}
       </button>
     </ion-list>
   </ion-content>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { RocketsPageModule } from '../pages/rockets/rockets.module';
 import { LaunchesPageModule } from '../pages/launches/launches.module';
 import { UpcomingLaunchesPageModule } from '../pages/upcoming-launches/upcoming-launches.module';
 import { PastLaunchesPageModule } from '../pages/past-launches/past-launches.module';
+import { LaunchesFiltersModalPageModule } from '../pages/launches-filters-modal/launches-filters-modal.module';
 
 @NgModule({
   declarations: [
@@ -30,6 +31,7 @@ import { PastLaunchesPageModule } from '../pages/past-launches/past-launches.mod
     LaunchesPageModule,
     UpcomingLaunchesPageModule,
     PastLaunchesPageModule,
+    LaunchesFiltersModalPageModule,
     IonicModule.forRoot(MyApp, {
       tabsPlacement: 'bottom',
     })

--- a/src/pages/about/about.html
+++ b/src/pages/about/about.html
@@ -1,5 +1,5 @@
 <ion-header>
-  <ion-navbar  color="primary">
+  <ion-navbar  color="spaceXHeader">
     <button ion-button menuToggle>
       <ion-icon name="menu"></ion-icon>
     </button>

--- a/src/pages/about/about.ts
+++ b/src/pages/about/about.ts
@@ -20,7 +20,6 @@ export class AboutPage {
     });
     loader.present();
     this.spaceXProvider.getCompagnyInfo().then(data => {
-      console.log(data);
       this.spaceXInfo = data;
       loader.dismiss();
     })

--- a/src/pages/capsules/capsules.html
+++ b/src/pages/capsules/capsules.html
@@ -6,7 +6,7 @@
 -->
 <ion-header>
 
-  <ion-navbar color="primary">
+  <ion-navbar color="spaceXHeader">
     <button ion-button menuToggle>
       <ion-icon name="menu"></ion-icon>
     </button>

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -1,5 +1,5 @@
 <ion-header>
-  <ion-navbar color="primary">
+  <ion-navbar color="spaceXHeader">
     <button ion-button menuToggle icon-only>
       <ion-icon name='menu'></ion-icon>
     </button>

--- a/src/pages/launches-filters-modal/launches-filters-modal.html
+++ b/src/pages/launches-filters-modal/launches-filters-modal.html
@@ -1,0 +1,81 @@
+<!--
+  Generated template for the LaunchesFiltersModalPage page.
+
+  See http://ionicframework.com/docs/components/#navigation for more info on
+  Ionic pages and navigation.
+-->
+<ion-header>
+
+  <ion-navbar>
+    <ion-buttons start>
+      <button ion-button (click)="resetFilters()">
+        Reset
+      </button>
+    </ion-buttons>
+
+    <ion-title>Filters</ion-title>
+
+    <ion-buttons end>
+      <button ion-button icon-only (click)="closeModal()">
+        <ion-icon name="close"></ion-icon>
+      </button>
+    </ion-buttons>
+  </ion-navbar>
+
+</ion-header>
+
+
+<ion-content>
+  <ion-list *ngIf="filters">
+    <ion-item-group>
+      <ion-item-divider color="light">Order</ion-item-divider>
+      <ion-item>
+        <ion-label>
+          Order
+        </ion-label>
+        <ion-select [(ngModel)]="filters.order">
+          <ion-option value="asc">asc</ion-option>
+          <ion-option value="desc">desc</ion-option>
+        </ion-select>
+      </ion-item>
+    </ion-item-group>
+
+    <ion-item-group>
+      <ion-item-divider color="light">Time</ion-item-divider>
+      <ion-item>
+        <ion-label>
+          Launch Year
+        </ion-label>
+        <ion-select [(ngModel)]="filters.launch_year">
+          <ion-option value="2006">2006</ion-option>
+          <ion-option value="2007">2007</ion-option>
+          <ion-option value="2008">2008</ion-option>
+          <ion-option value="2009">2009</ion-option>
+          <ion-option value="2010">2010</ion-option>
+          <ion-option value="2011">2011</ion-option>
+          <ion-option value="2012">2012</ion-option>
+          <ion-option value="2013">2013</ion-option>
+          <ion-option value="2014">2014</ion-option>
+          <ion-option value="2015">2015</ion-option>
+          <ion-option value="2016">2016</ion-option>
+          <ion-option value="2017">2017</ion-option>
+          <ion-option value="2018">2018</ion-option>
+        </ion-select>
+      </ion-item>
+
+      <ion-item>
+        <ion-label>
+          Reused Core
+        </ion-label>
+        <ion-select [(ngModel)]="filters.reused">
+          <ion-option value="true">Yes</ion-option>
+          <ion-option value="false">No</ion-option>
+        </ion-select>
+      </ion-item>
+    </ion-item-group>
+  </ion-list>
+</ion-content>
+
+<ion-footer no-padding no-margin>
+  <button ion-button (click)="submitNewFilters()"> submit </button>
+</ion-footer>

--- a/src/pages/launches-filters-modal/launches-filters-modal.module.ts
+++ b/src/pages/launches-filters-modal/launches-filters-modal.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { LaunchesFiltersModalPage } from './launches-filters-modal';
+
+@NgModule({
+  declarations: [
+    LaunchesFiltersModalPage,
+  ],
+  imports: [
+    IonicPageModule.forChild(LaunchesFiltersModalPage),
+  ],
+})
+export class LaunchesFiltersModalPageModule {}

--- a/src/pages/launches-filters-modal/launches-filters-modal.scss
+++ b/src/pages/launches-filters-modal/launches-filters-modal.scss
@@ -1,0 +1,3 @@
+page-launches-filters-modal {
+
+}

--- a/src/pages/launches-filters-modal/launches-filters-modal.ts
+++ b/src/pages/launches-filters-modal/launches-filters-modal.ts
@@ -1,0 +1,42 @@
+import { Component } from '@angular/core';
+import { IonicPage, NavController, NavParams, ViewController } from 'ionic-angular';
+
+/**
+ * Generated class for the LaunchesFiltersModalPage page.
+ *
+ * See https://ionicframework.com/docs/components/#navigation for more info on
+ * Ionic pages and navigation.
+ */
+
+@IonicPage()
+@Component({
+  selector: 'page-launches-filters-modal',
+  templateUrl: 'launches-filters-modal.html',
+})
+export class LaunchesFiltersModalPage {
+
+  filters: any;
+
+  constructor(public navCtrl: NavController, public navParams: NavParams, private viewCtrl: ViewController) {
+  }
+
+  ionViewDidLoad() {
+    const filters = this.navParams.get('currentFilters');
+    this.filters = filters;
+  }
+
+  closeModal() {
+    this.viewCtrl.dismiss();
+  }
+
+  resetFilters(){
+    this.filters = { order: 'desc' };
+    this.filters.launch_year = '';
+    this.filters.reused = '';
+  }
+
+  submitNewFilters(){
+    this.viewCtrl.dismiss(this.filters);
+  }
+
+}

--- a/src/pages/launches/launches.html
+++ b/src/pages/launches/launches.html
@@ -4,21 +4,10 @@
   See http://ionicframework.com/docs/components/#navigation for more info on
   Ionic pages and navigation.
 -->
-<ion-header>
 
-  <ion-navbar color="primary">
-    <button ion-button menuToggle>
-      <ion-icon name="menu"></ion-icon>
-    </button>
-    <ion-title>launches</ion-title>
-  </ion-navbar>
-
-</ion-header>
-
-
-<ion-content padding>
+<ion-content>
   <ion-tabs>
-    <ion-tab [root]="tab1Root" tabTitle="Past" tabIcon="home"></ion-tab>
-    <ion-tab [root]="tab2Root" tabTitle="Upcoming" tabIcon="home"></ion-tab>
+    <ion-tab [root]="tab1Root" tabTitle="Past"></ion-tab>
+    <ion-tab [root]="tab2Root" tabTitle="Upcoming"></ion-tab>
   </ion-tabs>
 </ion-content>

--- a/src/pages/launches/launches.ts
+++ b/src/pages/launches/launches.ts
@@ -22,10 +22,6 @@ export class LaunchesPage {
   tab2Root = UpcomingLaunchesPage;
 
   constructor(public navCtrl: NavController, public navParams: NavParams) {
-  }
 
-  ionViewDidLoad() {
-    console.log('ionViewDidLoad LaunchesPage');
   }
-
 }

--- a/src/pages/past-launches/past-launches.html
+++ b/src/pages/past-launches/past-launches.html
@@ -4,6 +4,28 @@
   See http://ionicframework.com/docs/components/#navigation for more info on
   Ionic pages and navigation.
 -->
-<ion-content padding>
+<ion-header>
 
+  <ion-navbar color="spaceXHeader">
+    <button ion-button menuToggle>
+      <ion-icon name="menu"></ion-icon>
+    </button>
+    <ion-title>Missions</ion-title>
+  </ion-navbar>
+
+</ion-header>
+
+<ion-content>
+
+  <ion-list *ngIf="pastLaunches">
+    <ion-item *ngFor="let launch of pastLaunches">
+      <ion-thumbnail item-start>
+        <img src="{{launch.links.mission_patch_small}}">
+      </ion-thumbnail>
+      <h2>{{ launch.mission_name }}</h2>
+      <p>{{ launch.launch_year }}</p>
+      <p>{{ launch.launch_site.site_name }}</p>
+      <button ion-button clear item-end>View</button>
+    </ion-item>
+  </ion-list>
 </ion-content>

--- a/src/pages/past-launches/past-launches.html
+++ b/src/pages/past-launches/past-launches.html
@@ -16,6 +16,11 @@
 </ion-header>
 
 <ion-content>
+  <ion-fab top right edge>
+    <button ion-fab mini (click)="openModal()">
+      <ion-icon name="options"></ion-icon>
+    </button>
+  </ion-fab>
 
   <ion-list *ngIf="pastLaunches">
     <ion-item *ngFor="let launch of pastLaunches">

--- a/src/pages/past-launches/past-launches.ts
+++ b/src/pages/past-launches/past-launches.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
-import { IonicPage, NavController, NavParams } from 'ionic-angular';
+import { IonicPage, NavController, NavParams, LoadingController, ModalController } from 'ionic-angular';
+import { SpaceXProvider } from '../../providers/space-x/space-x';
 
 /**
  * Generated class for the PastLaunchesPage page.
@@ -15,11 +16,24 @@ import { IonicPage, NavController, NavParams } from 'ionic-angular';
 })
 export class PastLaunchesPage {
 
-  constructor(public navCtrl: NavController, public navParams: NavParams) {
+  pastLaunches: any;
+  filters = {
+    order: 'desc',
+  };
+
+  constructor(public navCtrl: NavController, public navParams: NavParams, private spaceXProvider: SpaceXProvider, private modalCtrl: ModalController, private loadingCtrl: LoadingController) {
+    this.getPastLaunches(this.filters);
   }
 
-  ionViewDidLoad() {
-    console.log('ionViewDidLoad PastLaunchesPage');
+  getPastLaunches(filters){
+    let loader = this.loadingCtrl.create({
+      content: "Please wait...",
+    });
+    loader.present();
+    this.spaceXProvider.getPastLaunches(filters).then(data => {
+      this.pastLaunches = data;
+      loader.dismiss();
+    })
   }
 
 }

--- a/src/pages/past-launches/past-launches.ts
+++ b/src/pages/past-launches/past-launches.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams, LoadingController, ModalController } from 'ionic-angular';
 import { SpaceXProvider } from '../../providers/space-x/space-x';
+import { LaunchesFiltersModalPage } from '../launches-filters-modal/launches-filters-modal';
 
 /**
  * Generated class for the PastLaunchesPage page.
@@ -36,4 +37,20 @@ export class PastLaunchesPage {
     })
   }
 
+  openModal(){
+    const filtersModal = this.modalCtrl.create(LaunchesFiltersModalPage, { currentFilters: this.filters })
+    filtersModal.present();
+
+    filtersModal.onDidDismiss(newFilters => {
+      if (newFilters){
+        Object.keys(newFilters).forEach(filter => {
+          if (newFilters[filter] === ''){
+            delete newFilters[filter];
+          }
+        })
+        this.filters = newFilters;
+        this.getPastLaunches(this.filters);
+      }
+    });
+  }
 }

--- a/src/pages/rockets/rocket-details.html
+++ b/src/pages/rockets/rocket-details.html
@@ -6,7 +6,7 @@
 -->
 <ion-header>
 
-  <ion-navbar color="primary" *ngIf="rocket">
+  <ion-navbar color="spaceXHeader" *ngIf="rocket">
     <ion-title>{{ rocket.name }}</ion-title>
   </ion-navbar>
 

--- a/src/pages/rockets/rockets.html
+++ b/src/pages/rockets/rockets.html
@@ -6,7 +6,7 @@
 -->
 <ion-header>
 
-  <ion-navbar color="primary">
+  <ion-navbar color="spaceXHeader">
     <button ion-button menuToggle>
       <ion-icon name="menu"></ion-icon>
     </button>

--- a/src/pages/rockets/rockets.ts
+++ b/src/pages/rockets/rockets.ts
@@ -40,7 +40,6 @@ export class RocketsPage {
     });
     loader.present();
     this.spaceXProvider.getAllRockets().then(data => {
-      console.log(data);
       this.rocketList = data;
       loader.dismiss();
     })

--- a/src/pages/upcoming-launches/upcoming-launches.ts
+++ b/src/pages/upcoming-launches/upcoming-launches.ts
@@ -18,8 +18,4 @@ export class UpcomingLaunchesPage {
   constructor(public navCtrl: NavController, public navParams: NavParams) {
   }
 
-  ionViewDidLoad() {
-    console.log('ionViewDidLoad UpcomingLaunchesPage');
-  }
-
 }

--- a/src/providers/space-x/space-x.ts
+++ b/src/providers/space-x/space-x.ts
@@ -13,7 +13,6 @@ export class SpaceXProvider {
   apiUrl: string = 'https://api.spacexdata.com/v2';
 
   constructor(public http: HttpClient) {
-    console.log('Hello SpaceXProvider Provider');
   }
 
   getCompagnyInfo() {
@@ -47,7 +46,7 @@ export class SpaceXProvider {
   }
 
   getAllLaunches(filters){
-    let receivedFilters;
+    let receivedFilters = '';
     const filtersKeys = filters != null ? Object.keys(filters) : null;
     if (filtersKeys != null && filtersKeys.length > 0) {
       filtersKeys.forEach((filter, index) => {
@@ -55,7 +54,7 @@ export class SpaceXProvider {
           receivedFilters += `?${filter}=${encodeURIComponent(filters[filter])}`;
         }
         else {
-          receivedFilters += `$${filter}=${encodeURIComponent(filters[filter])}`;
+          receivedFilters += `&${filter}=${encodeURIComponent(filters[filter])}`;
         }
       });
     }
@@ -68,9 +67,21 @@ export class SpaceXProvider {
     })
   }
 
-  getPastLaunches(){
+  getPastLaunches(filters){
+    let receivedFilters = '';
+    const filtersKeys = filters != null ? Object.keys(filters) : null;
+    if (filtersKeys != null && filtersKeys.length > 0) {
+      filtersKeys.forEach((filter, index) => {
+        if (index === 0) {
+          receivedFilters += `?${filter}=${encodeURIComponent(filters[filter])}`;
+        }
+        else {
+          receivedFilters += `&${filter}=${encodeURIComponent(filters[filter])}`;
+        }
+      });
+    }
     return new Promise(resolve => {
-      this.http.get(`${this.apiUrl}/launches`).subscribe(data => {
+      this.http.get(`${this.apiUrl}/launches/${receivedFilters}`).subscribe(data => {
         resolve(data);
       }, err => {
         console.log(err);

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -34,11 +34,13 @@ $app-direction: ltr;
 // The "primary" color is the only required color in the map.
 
 $colors: (
-  primary:    #181c1f,
+  primary:    #488aff,
   secondary:  #32db64,
   danger:     #f53d3d,
   light:      #f4f4f4,
-  dark:       #222
+  dark:       #222,
+  spaceXHeader:       #21272b,
+  fabs:        #849199
 );
 
 


### PR DESCRIPTION
issue #2 

### What it does?

- Get past launches
- Apply a default filter ` order: 'desc'` when getting past launches
- Add a `fab button`which opens filters modal where you can specify your filters

- In the filters modql you can filter the past lauches by 
   - Order `desc`or `asc`
   - launch_year from `2006` to `2018`
   - reused `true`or `false`


### Screenshots
<img width="271" alt="pastlauches" src="https://user-images.githubusercontent.com/10242454/40743114-ede0e340-6450-11e8-9fdc-fce24bebca42.png">
